### PR TITLE
fix: Make response handling a tad more robust

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ pnpm-debug.log*
 *.njsproj
 *.sln
 *.sw?
+.log/

--- a/package-lock.json
+++ b/package-lock.json
@@ -17710,7 +17710,6 @@
       "integrity": "sha512-pM7CR3yXB6L8Gfn6EmX7FLNE3+V/15I3o33GkSNsWvgsMp6HVGXKkXgojrcfUUauyL1LZOdvTmu4enU2RePGHw==",
       "dev": true,
       "requires": {
-        "@babel/core": "^7.11.0",
         "@babel/helper-compilation-targets": "^7.9.6",
         "@babel/helper-module-imports": "^7.8.3",
         "@babel/plugin-proposal-class-properties": "^7.8.3",
@@ -17723,7 +17722,6 @@
         "@vue/babel-plugin-jsx": "^1.0.3",
         "@vue/babel-preset-jsx": "^1.2.4",
         "babel-plugin-dynamic-import-node": "^2.3.3",
-        "core-js": "^3.6.5",
         "core-js-compat": "^3.6.5",
         "semver": "^6.1.0"
       },

--- a/src/service/rating.service.ts
+++ b/src/service/rating.service.ts
@@ -64,10 +64,15 @@ class RatingService {
     }
     const code = TAXA[Math.floor(Math.random() * TAXA.length)]
     return fetch(PICTURE_API.replace('%code%', code))
-      .then(res => res.json())
-      .then(res => {
-        const imgIdx = Math.floor(Math.random() * Math.min(5, res.results.count))
-        if (res.results.count === 0 || !res.results?.content?.[imgIdx]) {
+      .then((res) => res.json())
+      .then((res) => {
+        const imgIdx = Math.floor(
+          Math.random() * Math.min(5, res.results.content.length)
+        )
+        if (
+          res.results?.content?.length === 0 ||
+          !res.results?.content?.[imgIdx]
+        ) {
           return this.fetchPicture(retry + 1)
         }
         return res.results.content[imgIdx]


### PR DESCRIPTION
iratebirds.app as seen in production has an issue due to an upstream change the behavior of a 3rd party API: Macaulay Library's public API does no longer provide consistent support for the number of items contained in the response.

This change addresses three things:

- Updates Node version to latest version of Node 16 LTS.
- Updates dependencies (`npm upgrade`) and addresses dependencies' vulnerabilities registered by the Node tooling (`npm audit fix`), as a result, updating several dependencies, as seen in 1ec1375aad586b0516cc6c2adb914db06d552b6c.
- Uses length of response array to select an image to display, instead of relying on responses's `count` element, which seems to be broken in above mentioned public API.
 